### PR TITLE
remove duplicate NeverAgain Pledge and The Groundwork

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -146,27 +146,6 @@
                             <td>NeverAgain is the pledge signed by technologists around the country who are pledging to refuse to build a database of people based on their Constitutionally-protected religious beliefs. The refuse to facilitate mass deportations of people the government believes to be undesirable. The pledge is no longer accepting individual signatories.</td>
                             <td>Built by <a href="#techsolidarity">Tech Solidarity</a></td>
                         </tr>
-                        <tr>
-                            <td><a href="http://neveragain.tech">NeverAgain Pledge</a></td>
-                            <td>NeverAgain is the pledge signed by technologists around the country who are pledging to refuse to build a database of people based on their Constitutionally-protected religious beliefs. The refuse to facilitate mass deportations of people the government believes to be undesirable. The pledge is no longer accepting individual signatories.</td>
-                            <td>Built by <a href="#techsolidarity">Tech Solidarity</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-            <h2 id="tools">Tools</h2>
-            <p>These are tools that have been developed to help activists build great things.</p>
-            </div>
-            <div class="col-md-12">
-                <table class="table table-bordered">
-                    <tbody>
-                        <tr>
-                          <td><a href="https://thegroundwork.com/">The Groundwork</a></td>
-                          <td>APIs and building blocks for grassroots organizing, fundraising, and supporter engagement with extensive <a href="https://developer.thegroundwork.com/">developer documentation</a>. Powered donations, mail, and engagement for <a href="https://www.hillaryclinton.com/">Hillary Clinton</a> during her campaign.</td>
-                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
The Groundwork is sadly shutting down (at least, last I heard from my campaign contacts), so we should remove it from this page. It's the only thing under the "Tools" section, so I just removed the entire thing.